### PR TITLE
fix: get_trust_anchors should return all trust anchors

### DIFF
--- a/certval/src/environment/pki_environment.rs
+++ b/certval/src/environment/pki_environment.rs
@@ -289,16 +289,13 @@ impl PkiEnvironment {
         Err(Error::Unrecognized)
     }
 
-    /// get_trust_anchor iterates over trust_anchor_sources until an authoritative answer is found
-    /// or all options have been exhausted
-    pub fn get_trust_anchors(&self) -> Result<Vec<&PDVTrustAnchorChoice>> {
-        for f in &self.trust_anchor_sources {
-            let r = f.get_trust_anchors();
-            if let Ok(r) = r {
-                return Ok(r);
-            }
-        }
-        Err(Error::Unrecognized)
+    /// get_trust_anchors iterates over trust_anchor_sources and collects all available trust anchors
+    pub fn get_trust_anchors(&self) -> Vec<&PDVTrustAnchorChoice> {
+        self.trust_anchor_sources
+            .iter()
+            .filter_map(|src| src.get_trust_anchors().ok())
+            .flatten()
+            .collect()
     }
 
     /// get_trust_anchor_by_hex_skid returns a reference to a trust anchor corresponding to the presented hexadecimal SKID.


### PR DESCRIPTION
Not just those from the first good source.