### PR TITLE
fix: do not stop at the first cert source that returns success

### DIFF
--- a/certval/src/environment/pki_environment.rs
+++ b/certval/src/environment/pki_environment.rs
@@ -493,16 +493,13 @@ impl PkiEnvironment {
         threshold: usize,
         time_of_interest: u64,
     ) -> Result<()> {
-        let mut last_error = Error::Unrecognized;
+        let mut last_error = None;
         for f in &self.certificate_sources {
-            match f.get_paths_for_target(pe, target, paths, threshold, time_of_interest) {
-                Ok(r) => return Ok(r),
-                Err(e) => {
-                    last_error = e;
-                }
-            }
+            if let Err(e) = f.get_paths_for_target(pe, target, paths, threshold, time_of_interest) {
+                last_error = Some(e);
+            };
         }
-        Err(last_error)
+        last_error.map_or_else(|| Ok(()), |e| Err(e))
     }
 
     /// add_oid_lookup adds a oid_lookup callback to the list used by get_trust_anchors.


### PR DESCRIPTION
CertSource.get_paths_for_target() may return Ok(()) even if no paths
have been found. If we encounter such a source before sources that
would add some paths, we will return early, missing those paths.

So make sure to query all cert sources, regardless of what any one
returns.
